### PR TITLE
[DM-28696] Representing missing values in the EFD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Build
         run: |
+          docker-compose up -d
           make html
 
       - name: Upload

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,9 @@ jobs:
         with:
           python-version: 3.7
 
+      - name: Install pandoc
+        run: sudo apt-get install -y pandoc
+
       - name: Python install
         run: |
           python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _build/
+data/

--- a/conf.py
+++ b/conf.py
@@ -4,16 +4,11 @@
 # see metadata.yaml in this repo to update document-specific metadata
 
 import os
-from documenteer.sphinxconfig.technoteconf import configure_technote
 
-# Ingest settings from metadata.yaml and use documenteer's configure_technote()
-# to build a Sphinx configuration that is injected into this script's global
-# namespace.
-metadata_path = os.path.join(os.path.dirname(__file__), 'metadata.yaml')
-with open(metadata_path, 'r') as f:
-    confs = configure_technote(f)
-g = globals()
-g.update(confs)
+from documenteer.conf.technote import *
+
+extensions.extend(['jupyter_sphinx'])
+exclude_patterns = ['venv', '.ipynb_checkpoints', 'README.rst']
 
 # Add intersphinx inventories as needed
 # http://www.sphinx-doc.org/en/stable/ext/intersphinx.html

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+---
+version: '3'
+services:
+
+  influxdb:
+    image: influxdb:1.8.3
+    container_name: influxdb
+    volumes:
+      - ./data/influxdb:/var/lib/influxdb
+    ports:
+      - "8086:8086"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-documenteer[technote]>=0.5.4,<0.6.0
+documenteer[technote]>=0.6.0
+jupyter-sphinx
+jupyter
+nbconvert

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ documenteer[technote]>=0.6.0
 jupyter-sphinx
 jupyter
 nbconvert
+aioinflux
+pandas


### PR DESCRIPTION
- Discuss alternatives for representing missing values
- Describe the data flow from the moment a CSC publishes a record until the moment it is read by the user
- Show how InfluxDB handles missing values
- InfluxDB sink connector ability to skip NaN values
- InfluxDB schemaless property can be used to handle missing values
- A dropped NaN becomes NaN again in the Pandas df returned by the EFD client.